### PR TITLE
allow cross version bungeeperms compatibility (3.0 changed some things)

### DIFF
--- a/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
+++ b/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
@@ -42,8 +42,7 @@ public class PermissionManager {
     public String getMainGroup(IPlayer player) {
         String bpgroup = null;
         // BungeePerms
-        BungeePerms bp = (BungeePerms) plugin.getProxy().getPluginManager().
-                getPlugin("BungeePerms");
+        BungeePerms bp = BungeePerms.getInstance();
         if (bp != null) {
             try {
                 User user = bp.getPermissionsManager().getUser(player.getName());
@@ -110,8 +109,7 @@ public class PermissionManager {
     public int comparePlayers(IPlayer p1, IPlayer p2) {
         // TODO Vault/Bukkit support
 
-        BungeePerms bp = (BungeePerms) plugin.getProxy().getPluginManager().
-                getPlugin("BungeePerms");
+        BungeePerms bp = BungeePerms.getInstance();
         if (bp != null) {
             try {
                 Group g1 = bp.getPermissionsManager().getMainGroup(bp.
@@ -158,8 +156,7 @@ public class PermissionManager {
 
     public String getPrefix(IPlayer player) {
         // BungeePerms
-        BungeePerms bp = (BungeePerms) plugin.getProxy().getPluginManager().
-                getPlugin("BungeePerms");
+        BungeePerms bp = BungeePerms.getInstance();
         String bpprefix = null;
         if (bp != null) {
             try {
@@ -201,8 +198,7 @@ public class PermissionManager {
 
     public String getDisplayPrefix(IPlayer player) {
         // BungeePerms
-        BungeePerms bp = (BungeePerms) plugin.getProxy().getPluginManager().
-                getPlugin("BungeePerms");
+        BungeePerms bp = BungeePerms.getInstance();
         String display = null;
         if (bp != null) {
             try {
@@ -224,8 +220,7 @@ public class PermissionManager {
 
     public String getSuffix(IPlayer player) {
         // BungeePerms
-        BungeePerms bp = (BungeePerms) plugin.getProxy().getPluginManager().
-                getPlugin("BungeePerms");
+        BungeePerms bp = BungeePerms.getInstance();
         String suffix = null;
         if (bp != null) {
             try {

--- a/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
+++ b/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
@@ -30,6 +30,7 @@ import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 
 import java.util.Collection;
+import net.md_5.bungee.api.plugin.Plugin;
 
 public class PermissionManager {
 
@@ -42,8 +43,9 @@ public class PermissionManager {
     public String getMainGroup(IPlayer player) {
         String bpgroup = null;
         // BungeePerms
-        BungeePerms bp = BungeePerms.getInstance();
-        if (bp != null) {
+        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
+        if (p != null) {
+            BungeePerms bp = BungeePerms.getInstance();
             try {
                 User user = bp.getPermissionsManager().getUser(player.getName());
                 Group mainGroup = null;
@@ -109,8 +111,9 @@ public class PermissionManager {
     public int comparePlayers(IPlayer p1, IPlayer p2) {
         // TODO Vault/Bukkit support
 
-        BungeePerms bp = BungeePerms.getInstance();
-        if (bp != null) {
+        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
+        if (p != null) {
+            BungeePerms bp = BungeePerms.getInstance();
             try {
                 Group g1 = bp.getPermissionsManager().getMainGroup(bp.
                         getPermissionsManager().getUser(p1.getName()));
@@ -156,9 +159,10 @@ public class PermissionManager {
 
     public String getPrefix(IPlayer player) {
         // BungeePerms
-        BungeePerms bp = BungeePerms.getInstance();
         String bpprefix = null;
-        if (bp != null) {
+        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
+        if (p != null) {
+            BungeePerms bp = BungeePerms.getInstance();
             try {
                 User user = bp.getPermissionsManager().getUser(player.getName());
                 if (user != null) {
@@ -198,9 +202,10 @@ public class PermissionManager {
 
     public String getDisplayPrefix(IPlayer player) {
         // BungeePerms
-        BungeePerms bp = BungeePerms.getInstance();
         String display = null;
-        if (bp != null) {
+        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
+        if (p != null) {
+            BungeePerms bp = BungeePerms.getInstance();
             try {
                 User user = bp.getPermissionsManager().getUser(player.getName());
                 if (user != null) {
@@ -220,9 +225,10 @@ public class PermissionManager {
 
     public String getSuffix(IPlayer player) {
         // BungeePerms
-        BungeePerms bp = BungeePerms.getInstance();
         String suffix = null;
-        if (bp != null) {
+        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
+        if (p != null) {
+            BungeePerms bp = BungeePerms.getInstance();
             try {
                 User user = bp.getPermissionsManager().getUser(player.getName());
                 if (user != null) {


### PR DESCRIPTION
bungee perms 3.0 is now different in structure
Bungeeperms.getInstance() remains the same
so this will garantee compatibility accross versions