### PR TITLE
Hidden Servers

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/BungeeTabListPlus.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/BungeeTabListPlus.java
@@ -446,7 +446,7 @@ public class BungeeTabListPlus {
      */
     public static boolean isHidden(IPlayer player, ProxiedPlayer viewer) {
         if (getInstance().getPermissionManager().hasPermission(viewer, "bungeetablistplus.seevanished")) return false;
-        return isHidden(player);
+        return isHidden(player) || isHiddenServer(player.getServer().orElse(null));
     }
 
     /**
@@ -462,6 +462,12 @@ public class BungeeTabListPlus {
         bukkitBridge.getPlayerInformation(player, Values.Player.SuperVanish.IsVanished).ifPresent(b -> hidden[0] |= b);
         bukkitBridge.getPlayerInformation(player, Values.Player.Essentials.IsVanished).ifPresent(b -> hidden[0] |= b);
         return hidden[0];
+    }
+
+    public static boolean isHiddenServer(ServerInfo server) {
+        if (server == null)
+            return false;
+        return getInstance().config.getMainConfig().hiddenServers.contains(server.getName());
     }
 
     /**

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
@@ -170,6 +170,19 @@ public class MainConfig extends Config {
     }
 
     @Comments({
+            "servers which you wish to hide from the global tabList",
+            "Note that this is different from excludeServers above: this hides all players on the hidden servers from appearing",
+            "on the tablist, whereas excluded servers' players are still on the BungeeTabListPlus tablist, but they do not see",
+            "the global tab list"
+    })
+    public List<String> hiddenServers = new ArrayList<>();
+
+    {
+        hiddenServers.add("server3");
+        hiddenServers.add("server9");
+    }
+
+    @Comments({
             "1.8 ONLY",
             "When enabled the tablist will adjust it's size to the number of players online/ slots used, instead of using",
             "the static tab_size set in bungee's config.yml.",


### PR DESCRIPTION
This commit adds a configuration option for servers that should be
hidden from the tablist altogether.

Addresses: https://github.com/CodeCrafter47/BungeeTabListPlus/issues/43