### PR TITLE
Added PermissionsEx support, choose User group by rank

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
@@ -244,6 +244,7 @@ public class MainConfig extends Configuration {
                 "Possible values:",
                 "AUTO        - take best source",
                 "BUKKIT      - take information from Bukkit/Vault",
+                "BUKKITPERMISSIONSEX      - take information from Bukkit/PermissionsEx",
                 "BUNGEEPERMS - take information from BungeePerms",
                 "BUNGEE      - take group from bungee, prefix from config.yml, permissions from bungee");
         write("permissionSource", permissionSource);

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/ConfigManager.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/ConfigManager.java
@@ -141,7 +141,8 @@ public class ConfigManager {
         if (!config.permissionSource.equalsIgnoreCase("AUTO") && !config.permissionSource.
                 equalsIgnoreCase("BUKKIT") && !config.permissionSource.
                 equalsIgnoreCase("BUNGEE") && !config.permissionSource.
-                equalsIgnoreCase("BUNGEEPERMS")) {
+                equalsIgnoreCase("BUNGEEPERMS") && !config.permissionSource.
+                equalsIgnoreCase("BUKKITPERMISSIONSEX")) {
             BungeeTabListPlus.getInstance().getPlugin().getLogger().warning(
                     "CONFIG-ERROR: Unknown value for 'permissionSource'");
         }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
@@ -52,6 +52,8 @@ public class PermissionManager {
             return group != null ? group : "";
         } else if (mode.equalsIgnoreCase("Bukkit")) {
             return plugin.getBridge().get(player, DataKeys.Vault_PermissionGroup).orElse("");
+		} else if (mode.equalsIgnoreCase("BukkitPermissionsEx")) {
+			return plugin.getBridge().get(player, DataKeys.PermissionsEx_PermissionGroup).orElse("");
         } else if (mode.equalsIgnoreCase("Bungee")) {
             return getMainGroupFromBungeeCord(player);
         } else {
@@ -179,6 +181,8 @@ public class PermissionManager {
             return prefix != null ? prefix : "";
         } else if (mode.equalsIgnoreCase("Bukkit")) {
             return plugin.getBridge().get(player, DataKeys.Vault_Prefix).orElse("");
+		} else if (mode.equalsIgnoreCase("BukkitPermissionsEx")) {
+			return plugin.getBridge().get(player, DataKeys.PermissionsEx_Prefix).orElse("");
         } else if (mode.equalsIgnoreCase("Bungee")) {
             String prefix = plugin.getConfigManager().getMainConfig().prefixes.get(getMainGroup(player));
             if (prefix != null) {
@@ -275,6 +279,8 @@ public class PermissionManager {
             return suffix == null ? "" : suffix;
         } else if (mode.equalsIgnoreCase("Bukkit")) {
             return plugin.getBridge().get(player, DataKeys.Vault_Suffix).orElse("");
+        } else if (mode.equalsIgnoreCase("BukkitPermissionsEx")) {
+            return plugin.getBridge().get(player, DataKeys.PermissionsEx_Suffix).orElse("");
         }
         String suffix = getSuffixFromBungeePerms(player);
         if (suffix != null) {

--- a/data/bukkit/core/pom.xml
+++ b/data/bukkit/core/pom.xml
@@ -64,5 +64,11 @@
             <version>2.2.9-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>codecrafter47.bungeetablistplus</groupId>
+            <artifactId>data-bukkit-permissionsex</artifactId>
+            <version>2.2.9-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/data/bukkit/core/src/main/java/codecrafter47/bungeetablistplus/data/bukkit/PlayerDataAccess.java
+++ b/data/bukkit/core/src/main/java/codecrafter47/bungeetablistplus/data/bukkit/PlayerDataAccess.java
@@ -25,6 +25,9 @@ import codecrafter47.bungeetablistplus.data.PermissionDataKey;
 import codecrafter47.bungeetablistplus.data.essentials.EssentialsIsVanishedProvider;
 import codecrafter47.bungeetablistplus.data.factions.*;
 import codecrafter47.bungeetablistplus.data.factionsuuid.FactionPlayerPowerProvider;
+import codecrafter47.bungeetablistplus.data.permissionsex.PermissionsExGroupProvider;
+import codecrafter47.bungeetablistplus.data.permissionsex.PermissionsExPrefixProvider;
+import codecrafter47.bungeetablistplus.data.permissionsex.PermissionsExSuffixProvider;
 import codecrafter47.bungeetablistplus.data.playerpoints.PlayerPointsProvider;
 import codecrafter47.bungeetablistplus.data.simpleclans.*;
 import codecrafter47.bungeetablistplus.data.supervanish.SuperVanishIsVanishedProvider;
@@ -75,6 +78,12 @@ public class PlayerDataAccess extends AbstractDataAccess<Player> {
             bind(DataKeys.Vault_Prefix, new VaultPrefixProvider());
             bind(DataKeys.Vault_Suffix, new VaultSuffixProvider());
         }
+        
+        if (Bukkit.getPluginManager().getPlugin("PermissionsEx") != null) {
+			bind(DataKeys.PermissionsEx_PermissionGroup, new PermissionsExGroupProvider());
+			bind(DataKeys.PermissionsEx_Prefix, new PermissionsExPrefixProvider());
+			bind(DataKeys.PermissionsEx_Suffix, new PermissionsExSuffixProvider());
+		}
 
         if (Bukkit.getPluginManager().getPlugin("VanishNoPacket") != null) {
             bind(DataKeys.VanishNoPacket_IsVanished, new VanishNoPacketIsVanishedProvider());

--- a/data/bukkit/permissionsex/pom.xml
+++ b/data/bukkit/permissionsex/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>data-bukkit-parent</artifactId>
+        <groupId>codecrafter47.bungeetablistplus</groupId>
+        <version>2.2.9-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>data-bukkit-permissionsex</artifactId>
+   <!-- TODO -->
+    <repositories>
+        <repository>
+            <id>vault-repo</id>
+            <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+         <id>baumscraft</id>
+         <url>http://baums-craft.net:12311/nexus/content/repositories/baumscraft</url>
+        </repository>
+   </repositories>
+
+    <dependencies>
+   <dependency>
+     <groupId>ru.tehkode</groupId>
+     <artifactId>PermissionsEx</artifactId>
+     <version>1.23.3</version>
+	        <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.bukkit</groupId>
+                    <artifactId>bukkit</artifactId>
+                </exclusion>
+            </exclusions>
+   </dependency>
+    </dependencies>
+</project>

--- a/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExDataProvider.java
+++ b/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExDataProvider.java
@@ -1,0 +1,67 @@
+/*
+ * BungeeTabListPlus - a BungeeCord plugin to customize the tablist
+ *
+ * Copyright (C) 2014 - 2015 Florian Stober
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package codecrafter47.bungeetablistplus.data.permissionsex;
+
+import org.bukkit.Bukkit;
+import org.bukkit.permissions.Permission;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.function.Function;
+
+public abstract class PermissionsExDataProvider<B, R> implements Function<B, R> {
+    @Override
+    public final R apply(B b) {
+        try {
+            return apply0(b);
+        } catch (Throwable th) {
+            throw new RuntimeException("Exception while querying data from PermissionsEx\n" + getPermissionsExInfo(), th);
+        }
+    }
+
+    protected abstract R apply0(B b);
+
+    private String getPermissionsExInfo() {
+        StringBuilder info = new StringBuilder();
+        Plugin permissionsex = Bukkit.getPluginManager().getPlugin("PermissionsEx");
+        if (permissionsex != null) {
+            info.append("PermissionsEx ").append(permissionsex.getDescription().getVersion()).append("\n");
+            try {
+                addPermissionInfo(info);
+            } catch (Throwable th) {
+                info.append(th.toString());
+            }
+        }
+        return info.toString();
+    }
+    
+    private void addPermissionInfo(StringBuilder info) {
+        RegisteredServiceProvider<Permission> rsp = Bukkit.getServicesManager().getRegistration(Permission.class);
+        if (rsp != null) {
+            Permission provider = rsp.getProvider();
+            if (provider != null) {
+                Plugin plugin = Bukkit.getPluginManager().getPlugin(provider.getName());
+                if (plugin != null) {
+                    info.append("Permissions ").append(plugin.getDescription().getName()).append(" ").append(plugin.getDescription().getVersion()).append("\n");
+                }
+            }
+        }
+    }
+}

--- a/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExGroupProvider.java
+++ b/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExGroupProvider.java
@@ -1,0 +1,45 @@
+/*
+ * BungeeTabListPlus - a BungeeCord plugin to customize the tablist
+ *
+ * Copyright (C) 2014 - 2015 Florian Stober
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package codecrafter47.bungeetablistplus.data.permissionsex;
+
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import ru.tehkode.permissions.PermissionGroup;
+import ru.tehkode.permissions.PermissionUser;
+import ru.tehkode.permissions.bukkit.PermissionsEx;
+
+public class PermissionsExGroupProvider extends PermissionsExDataProvider<Player, String> {
+	public String apply0(Player player) {
+		Plugin permissionsex = Bukkit.getPluginManager().getPlugin("PermissionsEx");
+		if (permissionsex != null && PermissionsEx.isAvailable()) {
+			
+			PermissionGroup maingroup = PermissionsExHelper
+					.getMainPermissionGroupFromRank(PermissionsEx.getUser(player));
+			
+			if (maingroup == null)
+				return null;
+			return maingroup.getName();
+		}
+		return null;
+	}
+}

--- a/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExHelper.java
+++ b/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExHelper.java
@@ -1,0 +1,26 @@
+package codecrafter47.bungeetablistplus.data.permissionsex;
+
+import java.util.List;
+
+import ru.tehkode.permissions.PermissionGroup;
+import ru.tehkode.permissions.PermissionUser;
+
+public class PermissionsExHelper {
+
+	public static PermissionGroup getMainPermissionGroupFromRank(PermissionUser pPermissionUser) {
+		if (pPermissionUser == null)
+			return null;
+
+		List<PermissionGroup> groups = pPermissionUser.getParents();
+		if (groups.size() <= 0)
+			return null;
+
+		PermissionGroup maingroup = null;
+		for (PermissionGroup pg : groups) {
+			if (pg.getRankLadder().equals("default") && (maingroup == null || pg.getRank() < maingroup.getRank()))
+				maingroup = pg;
+		}
+		return maingroup;
+	}
+
+}

--- a/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExPrefixProvider.java
+++ b/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExPrefixProvider.java
@@ -1,0 +1,55 @@
+/*
+ * BungeeTabListPlus - a BungeeCord plugin to customize the tablist
+ *
+ * Copyright (C) 2014 - 2015 Florian Stober
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package codecrafter47.bungeetablistplus.data.permissionsex;
+
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import ru.tehkode.permissions.PermissionGroup;
+import ru.tehkode.permissions.PermissionUser;
+import ru.tehkode.permissions.bukkit.PermissionsEx;
+
+public class PermissionsExPrefixProvider extends PermissionsExDataProvider<Player, String> {
+	public String apply0(Player player) {
+		Plugin permissionsex = Bukkit.getPluginManager().getPlugin("PermissionsEx");
+
+		if (permissionsex != null && PermissionsEx.isAvailable()) {
+			PermissionUser pu = PermissionsEx.getUser(player);
+
+			if (pu == null)
+				return null;
+
+			String pprefix = pu.getOwnPrefix();
+
+			if (pprefix != null && !pprefix.equals(""))
+				return pu.getOwnPrefix();
+
+			PermissionGroup maingroup = PermissionsExHelper.getMainPermissionGroupFromRank(pu);
+
+			if (maingroup == null)
+				return null;
+			return maingroup.getPrefix();
+		}
+		return null;
+	}
+}

--- a/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExSuffixProvider.java
+++ b/data/bukkit/permissionsex/src/main/java/codecrafter47/bungeetablistplus/data/permissionsex/PermissionsExSuffixProvider.java
@@ -1,0 +1,53 @@
+/*
+ * BungeeTabListPlus - a BungeeCord plugin to customize the tablist
+ *
+ * Copyright (C) 2014 - 2015 Florian Stober
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package codecrafter47.bungeetablistplus.data.permissionsex;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import ru.tehkode.permissions.PermissionGroup;
+import ru.tehkode.permissions.PermissionUser;
+import ru.tehkode.permissions.bukkit.PermissionsEx;
+
+public class PermissionsExSuffixProvider extends PermissionsExDataProvider<Player, String> {
+	public String apply0(Player player) {
+		Plugin permissionsex = Bukkit.getPluginManager().getPlugin("PermissionsEx");
+
+		if (permissionsex != null && PermissionsEx.isAvailable()) {
+			PermissionUser pu = PermissionsEx.getUser(player);
+
+			if (pu == null)
+				return null;
+
+			String psuffix = pu.getOwnSuffix();
+
+			if (psuffix != null && !psuffix.equals(""))
+				return pu.getOwnSuffix();
+
+			PermissionGroup maingroup = PermissionsExHelper.getMainPermissionGroupFromRank(pu);
+
+			if (maingroup == null)
+				return null;
+			return maingroup.getSuffix();
+		}
+		return null;
+	}
+}

--- a/data/bukkit/pom.xml
+++ b/data/bukkit/pom.xml
@@ -20,6 +20,7 @@
         <module>supervanish</module>
         <module>simpleclans</module>
         <module>essentials</module>
+        <module>permissionsex</module>
     </modules>
 
     <dependencies>

--- a/data/core/src/main/java/codecrafter47/bungeetablistplus/data/DataKeys.java
+++ b/data/core/src/main/java/codecrafter47/bungeetablistplus/data/DataKeys.java
@@ -40,6 +40,9 @@ public class DataKeys {
     public final static DataKey<String> Vault_Suffix = DataKey.builder().player().id("vault:suffix").build();
     public final static DataKey<String> Vault_PermissionGroup = DataKey.builder().player().id("vault:permgroup").build();
     public final static DataKey<Double> Vault_Balance = DataKey.builder().player().id("vault:balance").build();
+    public final static DataKey<String> PermissionsEx_Prefix = DataKey.builder().player().id("permissionsex:prefix").build();
+    public final static DataKey<String> PermissionsEx_Suffix = DataKey.builder().player().id("permissionsex:suffix").build();
+    public final static DataKey<String> PermissionsEx_PermissionGroup = DataKey.builder().player().id("permissionsex:permgroup").build();
     public final static DataKey<Boolean> VanishNoPacket_IsVanished = DataKey.builder().player().id("vanishnopacket:isvanished").build();
     public final static DataKey<Integer> PlayerPoints_Points = DataKey.builder().player().id("playerpoints:points").build();
     public final static DataKey<String> Factions_FactionName = DataKey.builder().player().id("factions:factionname").build();


### PR DESCRIPTION
This version uses the group with the smallest rank in the default ladder
(highest priority), this does only work, if all groups are ranked