### PR TITLE
Allows custom permission plugins hook

### DIFF
--- a/api-bungee/src/main/java/codecrafter47/bungeetablistplus/api/bungee/CustomGroupProvider.java
+++ b/api-bungee/src/main/java/codecrafter47/bungeetablistplus/api/bungee/CustomGroupProvider.java
@@ -1,0 +1,16 @@
+package codecrafter47.bungeetablistplus.api.bungee;
+
+/**
+ *
+ * @author James
+ * 
+ * mode = CustomPlugin
+ */
+public interface CustomGroupProvider {
+    
+    public String getMainGroup(IPlayer player);
+    
+    public String getPrefix(IPlayer player);
+    
+    public String getSuffix(IPlayer player);
+}

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
@@ -252,7 +252,8 @@ public class MainConfig extends Configuration {
                 "BUKKIT      - take information from Bukkit/Vault",
                 "BUKKITPERMISSIONSEX      - take information from Bukkit/PermissionsEx",
                 "BUNGEEPERMS - take information from BungeePerms",
-                "BUNGEE      - take group from bungee, prefix from config.yml, permissions from bungee");
+                "BUNGEE      - take group from bungee, prefix from config.yml, permissions from bungee",
+                "CUSTOMPLUGIN     - take group external plugin that hooks into BTLP");
         write("permissionSource", permissionSource);
 
         writeComment("whether to show players in spectator mode");

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/ConfigManager.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/ConfigManager.java
@@ -142,7 +142,8 @@ public class ConfigManager {
                 equalsIgnoreCase("BUKKIT") && !config.permissionSource.
                 equalsIgnoreCase("BUNGEE") && !config.permissionSource.
                 equalsIgnoreCase("BUNGEEPERMS") && !config.permissionSource.
-                equalsIgnoreCase("BUKKITPERMISSIONSEX")) {
+                equalsIgnoreCase("BUKKITPERMISSIONSEX") && !config.permissionSource.
+                equalsIgnoreCase("CUSTOMPLUGIN")) {
             BungeeTabListPlus.getInstance().getPlugin().getLogger().warning(
                     "CONFIG-ERROR: Unknown value for 'permissionSource'");
         }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
@@ -19,6 +19,7 @@
 package codecrafter47.bungeetablistplus.managers;
 
 import codecrafter47.bungeetablistplus.BungeeTabListPlus;
+import codecrafter47.bungeetablistplus.api.bungee.CustomGroupProvider;
 import codecrafter47.bungeetablistplus.api.bungee.IPlayer;
 import codecrafter47.bungeetablistplus.api.bungee.tablist.TabListContext;
 import codecrafter47.bungeetablistplus.data.DataKey;
@@ -41,6 +42,7 @@ import java.util.logging.Level;
 public class PermissionManager {
 
     private final BungeeTabListPlus plugin;
+    public static CustomGroupProvider customGroupProvider = null;
 
     public PermissionManager(BungeeTabListPlus plugin) {
         this.plugin = plugin;
@@ -50,6 +52,8 @@ public class PermissionManager {
         String mode = plugin.getConfigManager().getMainConfig().permissionSource;
         if (mode.equalsIgnoreCase("BungeePerms")) {
             return ((Player) player).get(DataKeys.BungeePerms_PrimaryGroup).orElse("");
+        } else if (mode.equalsIgnoreCase("CustomPlugin")) {
+            return customGroupProvider != null ? customGroupProvider.getMainGroup(player) : "default";
         } else if (mode.equalsIgnoreCase("Bukkit")) {
             return ((Player) player).get(DataKeys.Vault_PermissionGroup).orElse("");
         } else if (mode.equalsIgnoreCase("BukkitPermissionsEx")) {
@@ -223,6 +227,8 @@ public class PermissionManager {
         String mode = plugin.getConfigManager().getMainConfig().permissionSource;
         if (mode.equalsIgnoreCase("BungeePerms")) {
             return ((Player) player).get(DataKeys.BungeePerms_Prefix).orElse("");
+        } else if (mode.equalsIgnoreCase("CustomPlugin")) {
+            return customGroupProvider != null ? customGroupProvider.getPrefix(player) : "";
         } else if (mode.equalsIgnoreCase("Bukkit")) {
             return ((Player) player).get(DataKeys.Vault_Prefix).orElse("");
         } else if (mode.equalsIgnoreCase("BukkitPermissionsEx")) {
@@ -319,6 +325,8 @@ public class PermissionManager {
         String mode = plugin.getConfigManager().getMainConfig().permissionSource;
         if (mode.equalsIgnoreCase("BungeePerms")) {
             return ((Player) player).get(DataKeys.BungeePerms_Suffix).orElse("");
+        } else if (mode.equalsIgnoreCase("CustomPlugin")) {
+            return customGroupProvider != null ? customGroupProvider.getSuffix(player) : "";
         } else if (mode.equalsIgnoreCase("Bukkit")) {
             return ((Player) player).get(DataKeys.Vault_Suffix).orElse("");
         } else if (mode.equalsIgnoreCase("BukkitPermissionsEx")) {


### PR DESCRIPTION
Added method to allow custom plugins to hook into the tablist for
permissions.

This would allow plugins like on our server to hook into your plugin without having to make a hacked (in terms of deleting repo/jar for it to build) up version of BungeeTabListPlus in order just to add a few lines of code.


Here is a sample of what my plugin does to hook into it now.



https://gist.github.com/James137137/0a96e1caf4417cdc7cad