### PR TITLE
allow proxy display name to be used in player lines

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/BasicPlaceholders.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/BasicPlaceholders.java
@@ -93,6 +93,11 @@ public class BasicPlaceholders extends PlaceholderProvider {
                 return ((ConnectedPlayer) context.getPlayer()).getPlayer().getDisplayName();
             return context.getPlayer().getName();
         });
+        bind("proxydisplayname").alias("player").to(context -> {
+            if (context.getPlayer() instanceof ConnectedPlayer)
+                return ((ConnectedPlayer) context.getPlayer()).getPlayer().getDisplayName();
+            return context.getPlayer().getName();
+        });
         bind("rawname").to(context -> context.getPlayer().getName());
         bind("server").to(context -> context.getServerGroup().map(ServerGroup::getName).orElse(""));
         bind("config_prefix").to(context -> BungeeTabListPlus.getInstance().getPermissionManager().getConfigPrefix(context, context.getPlayer()));


### PR DESCRIPTION
please allow option, change the bind name if you want, but i need a way to use the proxy display name rather than the bukkit names or raw name while using the bukkit bridge

