### PR TITLE
Add LuckPerms support

### DIFF
--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -35,34 +35,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>net.alpenblock</groupId>
-            <artifactId>BungeePerms</artifactId>
-            <version>3.0-dev-52</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.md-5</groupId>
-                    <artifactId>bungeecord-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.spigotmc</groupId>
-                    <artifactId>spigot-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sk89q</groupId>
-                    <artifactId>worldedit</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.milkbowl.vault</groupId>
-                    <artifactId>Vault</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.ess3</groupId>
-                    <artifactId>Essentials</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>com.imaginarycode.minecraft</groupId>
             <artifactId>RedisBungee</artifactId>
             <version>0.3.5-SNAPSHOT</version>

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/config/MainConfig.java
@@ -66,6 +66,7 @@ public class MainConfig implements UpdatableConfig {
             "AUTO        - take best source",
             "BUKKIT      - take information from Bukkit/Vault",
             "BUNGEEPERMS - take information from BungeePerms",
+            "LUCKPERMS   - take information from LuckPerms",
             "BUNGEE      - take group from bungee, prefix from config.yml, permissions from bungee",
             "This option will be removed soon. Don't use it anymore."
     })

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/config/PermissionSource.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/config/PermissionSource.java
@@ -20,5 +20,5 @@
 package codecrafter47.bungeetablistplus.config;
 
 public enum PermissionSource {
-    AUTO, BUKKIT, BUNGEE, BUNGEEPERMS
+    AUTO, BUKKIT, BUNGEE, BUNGEEPERMS, LUCKPERMS
 }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
@@ -18,26 +18,20 @@
  */
 package codecrafter47.bungeetablistplus.managers;
 
+import de.codecrafter47.data.api.DataKey;
+import de.codecrafter47.data.bungee.api.BungeeData;
+import de.codecrafter47.data.minecraft.api.MinecraftData;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+
 import codecrafter47.bungeetablistplus.BungeeTabListPlus;
 import codecrafter47.bungeetablistplus.api.bungee.IPlayer;
 import codecrafter47.bungeetablistplus.api.bungee.tablist.TabListContext;
 import codecrafter47.bungeetablistplus.player.ConnectedPlayer;
 import codecrafter47.bungeetablistplus.player.Player;
-import de.codecrafter47.data.api.DataKey;
-import de.codecrafter47.data.bungee.api.BungeeData;
-import de.codecrafter47.data.minecraft.api.MinecraftData;
-import net.alpenblock.bungeeperms.BungeePerms;
-import net.alpenblock.bungeeperms.Group;
-import net.alpenblock.bungeeperms.PermissionsManager;
-import net.alpenblock.bungeeperms.User;
-import net.md_5.bungee.api.CommandSender;
-import net.md_5.bungee.api.ProxyServer;
-import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.plugin.Plugin;
 
-import java.util.Collection;
 import java.util.Optional;
-import java.util.logging.Level;
 
 public class PermissionManager {
 
@@ -55,94 +49,27 @@ public class PermissionManager {
                 return ((Player) player).getOpt(BungeeData.BungeeCord_PrimaryGroup).orElse("default");
             case BUNGEEPERMS:
                 return ((Player) player).getOpt(BungeeData.BungeePerms_PrimaryGroup).orElse("");
+            case LUCKPERMS:
+                return ((Player) player).getOpt(BungeeData.LuckPerms_PrimaryGroup).orElse("");
             case AUTO:
             default:
-                Optional<String> group = ((Player) player).getOpt(BungeeData.BungeePerms_PrimaryGroup);
-                if (group.isPresent()) {
-                    return group.get();
+                Optional<String> ret = ((Player) player).getOpt(BungeeData.BungeePerms_PrimaryGroup);
+                if (ret.isPresent()) {
+                    return ret.get();
                 }
-                Optional<String> optional = ((Player) player).getOpt(MinecraftData.Permissions_PermissionGroup);
-                if (optional.isPresent()) {
-                    return optional.get();
-                } else {
-                    return ((Player) player).getOpt(BungeeData.BungeeCord_PrimaryGroup).orElse("default");
-                }
-        }
-    }
 
-    String getMainGroupFromBungeeCord(ProxiedPlayer proxiedPlayer) {
-        if (proxiedPlayer != null) {
-            Collection<String> groups = proxiedPlayer.getGroups();
-            if (groups.size() == 1) {
-                return groups.iterator().next();
-            }
-            for (String group : groups) {
-                if (!group.equals("default")) {
-                    return group;
+                ret = ((Player) player).getOpt(BungeeData.LuckPerms_PrimaryGroup);
+                if (ret.isPresent()) {
+                    return ret.get();
                 }
-            }
-        }
-        return "default";
-    }
 
-    String getMainGroupFromBungeePerms(ProxiedPlayer player) {
-        Plugin p = ProxyServer.getInstance().getPluginManager().getPlugin("BungeePerms");
-        if (p != null) {
-            BungeePerms bp = BungeePerms.getInstance();
-            try {
-                PermissionsManager pm = bp.getPermissionsManager();
-                if (pm != null) {
-                    User user = pm.getUser(player.getName());
-                    Group mainGroup = null;
-                    if (user != null) {
-                        mainGroup = pm.getMainGroup(user);
-                    }
-                    if (mainGroup == null) {
-                        if (!pm.getDefaultGroups().isEmpty()) {
-                            mainGroup = pm.getDefaultGroups().get(0);
-                            for (int i = 1; i < pm.getDefaultGroups().size(); ++i) {
-                                if (pm.getDefaultGroups().get(i).getWeight() < mainGroup.getWeight()) {
-                                    mainGroup = pm.getDefaultGroups().get(i);
-                                }
-                            }
-                        }
-                    }
-
-                    if (mainGroup != null) {
-                        return mainGroup.getName();
-                    }
+                ret = ((Player) player).getOpt(MinecraftData.Permissions_PermissionGroup);
+                if (ret.isPresent()) {
+                    return ret.get();
                 }
-            } catch (NullPointerException ex) {
-                BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-            } catch (Throwable th) {
-                BungeeTabListPlus.getInstance().reportError(th);
-            }
-        }
-        return null;
-    }
 
-    Integer getBungeePermsRank(ProxiedPlayer player) {
-        try {
-            Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
-            if (p != null) {
-                BungeePerms bp = BungeePerms.getInstance();
-                PermissionsManager pm = bp.getPermissionsManager();
-                if (pm != null) {
-                    User user = pm.getUser(player.getName());
-                    if (user != null) {
-                        Group mainGroup = pm.getMainGroup(user);
-                        if (mainGroup != null) {
-                            return mainGroup.getRank();
-                        }
-                    }
-                }
-            }
-        } catch (NullPointerException ex) {
-            BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-        } catch (Throwable th) {
-            BungeeTabListPlus.getInstance().reportError(th);
+                return ((Player) player).getOpt(BungeeData.BungeeCord_PrimaryGroup).orElse("default");
         }
-        return null;
     }
 
     public int comparePlayers(IPlayer p1, IPlayer p2) {
@@ -167,10 +94,23 @@ public class PermissionManager {
                 Optional<Integer> p2Rank = ((Player) p2).getOpt(BungeeData.BungeePerms_Rank);
                 return p1Rank.orElse(Integer.MAX_VALUE) - p2Rank.orElse(Integer.MAX_VALUE);
             }
+            case LUCKPERMS: {
+                Optional<Integer> p1Rank = ((Player) p1).getOpt(BungeeData.LuckPerms_Weight);
+                Optional<Integer> p2Rank = ((Player) p2).getOpt(BungeeData.LuckPerms_Weight);
+                return p1Rank.orElse(Integer.MAX_VALUE) - p2Rank.orElse(Integer.MAX_VALUE);
+            }
             case AUTO:
             default: {
                 Optional<Integer> p1Rank = ((Player) p1).getOpt(BungeeData.BungeePerms_Rank);
                 Optional<Integer> p2Rank = ((Player) p2).getOpt(BungeeData.BungeePerms_Rank);
+                if (p1Rank.isPresent() || p2Rank.isPresent()) {
+                    return p1Rank.orElse(Integer.MAX_VALUE) - p2Rank.orElse(Integer.MAX_VALUE);
+                }
+            }
+
+            {
+                Optional<Integer> p1Rank = ((Player) p1).getOpt(BungeeData.LuckPerms_Weight);
+                Optional<Integer> p2Rank = ((Player) p2).getOpt(BungeeData.LuckPerms_Weight);
                 if (p1Rank.isPresent() || p2Rank.isPresent()) {
                     return p1Rank.orElse(Integer.MAX_VALUE) - p2Rank.orElse(Integer.MAX_VALUE);
                 }
@@ -192,7 +132,6 @@ public class PermissionManager {
                 }
             }
 
-            // BungeeCord
             {
                 Optional<Integer> p1Rank = ((Player) p1).getOpt(BungeeData.BungeeCord_Rank);
                 Optional<Integer> p2Rank = ((Player) p2).getOpt(BungeeData.BungeeCord_Rank);
@@ -204,19 +143,6 @@ public class PermissionManager {
         }
     }
 
-    int getBungeeCordRank(ProxiedPlayer player) {
-        int rank = 0;
-        for (String group : player.getGroups()) {
-            if (!group.equals("default")) {
-                rank += 1;
-            }
-            if (group.equals("admin")) {
-                rank += 2;
-            }
-        }
-        return Integer.MAX_VALUE - rank;
-    }
-
     public String getPrefix(TabListContext context) {
         IPlayer player = context.getPlayer();
         switch (plugin.getConfig().permissionSourceValue()) {
@@ -226,13 +152,26 @@ public class PermissionManager {
                 return getConfigPrefix(context, player);
             case BUNGEEPERMS:
                 return ((Player) player).getOpt(BungeeData.BungeePerms_Prefix).orElse("");
+            case LUCKPERMS:
+                return ((Player) player).getOpt(BungeeData.LuckPerms_Prefix).orElse("");
             case AUTO:
             default:
                 String prefix = getConfigPrefix(context, player);
                 if (!prefix.isEmpty()) {
                     return prefix;
                 }
-                return ((Player) player).getOpt(BungeeData.BungeePerms_Prefix).orElseGet(() -> ((Player) player).getOpt(MinecraftData.Permissions_Prefix).orElse(""));
+
+                Optional<String> ret = ((Player) player).getOpt(BungeeData.BungeePerms_Prefix);
+                if (ret.isPresent()) {
+                    return ret.get();
+                }
+
+                ret = ((Player) player).getOpt(BungeeData.LuckPerms_Prefix);
+                if (ret.isPresent()) {
+                    return ret.get();
+                }
+
+                return  ((Player) player).getOpt(MinecraftData.Permissions_Prefix).orElse("");
         }
     }
 
@@ -244,122 +183,6 @@ public class PermissionManager {
         return prefix != null ? prefix : "";
     }
 
-    String getPrefixFromBungeePerms(ProxiedPlayer player) {
-        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
-        if (p != null) {
-            BungeePerms bp = BungeePerms.getInstance();
-            try {
-                PermissionsManager pm = bp.getPermissionsManager();
-                if (pm != null) {
-                    User user = pm.getUser(player.getName());
-                    if (user != null) {
-                        if (isBungeePerms3()) {
-                            return user.buildPrefix();
-                        } else {
-                            Group mainGroup = pm.getMainGroup(user);
-                            if (mainGroup != null) {
-                                return mainGroup.getPrefix();
-                            }
-                        }
-                    }
-                }
-            } catch (NullPointerException ex) {
-                BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-            } catch (Throwable th) {
-                BungeeTabListPlus.getInstance().reportError(th);
-            }
-        }
-        return null;
-    }
-
-    String getPrimaryGroupPrefixFromBungeePerms(ProxiedPlayer player) {
-        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
-        if (p != null) {
-            BungeePerms bp = BungeePerms.getInstance();
-            try {
-                PermissionsManager pm = bp.getPermissionsManager();
-                if (pm != null) {
-                    User user = pm.getUser(player.getName());
-                    if (user != null) {
-                        Group mainGroup = pm.getMainGroup(user);
-                        if (mainGroup != null) {
-                            return mainGroup.getPrefix();
-                        }
-                    }
-                }
-            } catch (NullPointerException ex) {
-                BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-            } catch (Throwable th) {
-                BungeeTabListPlus.getInstance().reportError(th);
-            }
-        }
-        return null;
-    }
-
-    String getPlayerPrefixFromBungeePerms(ProxiedPlayer player) {
-        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
-        if (isBungeePerms3()) {
-            if (p != null) {
-                BungeePerms bp = BungeePerms.getInstance();
-                try {
-                    PermissionsManager pm = bp.getPermissionsManager();
-                    if (pm != null) {
-                        User user = pm.getUser(player.getName());
-                        if (user != null) {
-                            return user.getPrefix();
-                        }
-                    }
-                } catch (NullPointerException ex) {
-                    BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-                } catch (Throwable th) {
-                    BungeeTabListPlus.getInstance().reportError(th);
-                }
-            }
-        }
-        return null;
-    }
-
-    String getDisplayPrefix(ProxiedPlayer player) {
-        // BungeePerms
-        String display = null;
-        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
-        if (p != null) {
-            BungeePerms bp = BungeePerms.getInstance();
-            try {
-                PermissionsManager pm = bp.getPermissionsManager();
-                if (pm != null) {
-                    User user = pm.getUser(player.getName());
-                    if (user != null) {
-                        if (isBungeePerms3()) {
-                            display = user.getDisplay();
-                            if (display == null || display.isEmpty()) {
-                                Group group = pm.getMainGroup(user);
-                                if (group != null) {
-                                    display = group.getDisplay();
-                                }
-                            }
-                        } else {
-                            Group group = pm.getMainGroup(user);
-                            if (group != null) {
-                                display = group.getDisplay();
-                            }
-                        }
-                    }
-                }
-            } catch (NullPointerException ex) {
-                BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-            } catch (Throwable th) {
-                BungeeTabListPlus.getInstance().reportError(th);
-            }
-        }
-
-        if (display == null) {
-            display = "";
-        }
-
-        return display;
-    }
-
     public String getSuffix(IPlayer player) {
         switch (plugin.getConfig().permissionSourceValue()) {
             case BUKKIT:
@@ -367,38 +190,22 @@ public class PermissionManager {
             case BUNGEE:
             case BUNGEEPERMS:
                 return ((Player) player).getOpt(BungeeData.BungeePerms_Suffix).orElse("");
+            case LUCKPERMS:
+                return ((Player) player).getOpt(BungeeData.LuckPerms_Suffix).orElse("");
             case AUTO:
             default:
-                return ((Player) player).getOpt(BungeeData.BungeePerms_Suffix).orElseGet(() -> ((Player) player).getOpt(MinecraftData.Permissions_Suffix).orElse(""));
-        }
-    }
-
-    String getSuffixFromBungeePerms(ProxiedPlayer player) {
-        Plugin p = plugin.getProxy().getPluginManager().getPlugin("BungeePerms");
-        if (p != null) {
-            BungeePerms bp = BungeePerms.getInstance();
-            try {
-                PermissionsManager pm = bp.getPermissionsManager();
-                if (pm != null) {
-                    User user = pm.getUser(player.getName());
-                    if (user != null) {
-                        if (isBungeePerms3()) {
-                            return user.buildSuffix();
-                        } else {
-                            Group group = pm.getMainGroup(user);
-                            if (group != null) {
-                                return group.getSuffix();
-                            }
-                        }
-                    }
+                Optional<String> ret = ((Player) player).getOpt(BungeeData.BungeePerms_Suffix);
+                if (ret.isPresent()) {
+                    return ret.get();
                 }
-            } catch (NullPointerException ex) {
-                BungeeTabListPlus.getInstance().getLogger().log(Level.SEVERE, "An error occurred while querying data from BungeePerms. Make sure you have configured BungeePerms to use it's uuidPlayerDB.", ex);
-            } catch (Throwable th) {
-                BungeeTabListPlus.getInstance().reportError(th);
-            }
+
+                ret = ((Player) player).getOpt(BungeeData.LuckPerms_Suffix);
+                if (ret.isPresent()) {
+                    return ret.get();
+                }
+
+                return ((Player) player).getOpt(MinecraftData.Permissions_Suffix).orElse("");
         }
-        return null;
     }
 
     public boolean hasPermission(CommandSender sender, String permission) {
@@ -418,18 +225,5 @@ public class PermissionManager {
         }
 
         return false;
-    }
-
-    private boolean isBungeePerms3() {
-        return isClassPresent("net.alpenblock.bungeeperms.platform.bungee.BungeePlugin");
-    }
-
-    private boolean isClassPresent(String name) {
-        try {
-            Class.forName(name);
-            return true;
-        } catch (ClassNotFoundException ignored) {
-            return false;
-        }
     }
 }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/managers/PermissionManager.java
@@ -21,10 +21,8 @@ package codecrafter47.bungeetablistplus.managers;
 import de.codecrafter47.data.api.DataKey;
 import de.codecrafter47.data.bungee.api.BungeeData;
 import de.codecrafter47.data.minecraft.api.MinecraftData;
-
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-
 import codecrafter47.bungeetablistplus.BungeeTabListPlus;
 import codecrafter47.bungeetablistplus.api.bungee.IPlayer;
 import codecrafter47.bungeetablistplus.api.bungee.tablist.TabListContext;

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/BasicPlaceholders.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/BasicPlaceholders.java
@@ -133,6 +133,9 @@ public class BasicPlaceholders extends PlaceholderProvider {
         bind("bungeeperms_group").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.BungeePerms_PrimaryGroup).orElse(""));
         bind("bungeeperms_primary_group_prefix").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.BungeePerms_PrimaryGroupPrefix).orElse(""));
         bind("bungeeperms_player_prefix").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.BungeePerms_PlayerPrefix).orElse(""));
+        bind("luckperms_prefix").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.LuckPerms_Prefix).orElse(""));
+        bind("luckperms_suffix").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.LuckPerms_Suffix).orElse(""));
+        bind("luckperms_primary_group").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.LuckPerms_PrimaryGroup).orElse(""));
         bind("clientVersion").to(context -> ((Player) context.getPlayer()).getOpt(BungeeData.ClientVersion).orElse("unknown"));
         bind("ping").to(context -> String.format("%d", context.getPlayer().getPing()));
         bind("group").to(context -> BungeeTabListPlus.getInstance().getPermissionManager().getMainGroup(context.getPlayer()));

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/Placeholder.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/Placeholder.java
@@ -60,6 +60,9 @@ public abstract class Placeholder {
         playerPlaceholders.put("bungeeperms_primary_group", ofStringData(BungeeData.BungeePerms_PrimaryGroup));
         playerPlaceholders.put("bungeeperms_primary_group_prefix", ofStringData(BungeeData.BungeePerms_PrimaryGroupPrefix));
         playerPlaceholders.put("bungeeperms_user_prefix", ofStringData(BungeeData.BungeePerms_PlayerPrefix));
+        playerPlaceholders.put("luckperms_prefix", ofStringData(BungeeData.LuckPerms_Prefix));
+        playerPlaceholders.put("luckperms_suffix", ofStringData(BungeeData.LuckPerms_Suffix));
+        playerPlaceholders.put("luckperms_primary_group", ofStringData(BungeeData.LuckPerms_PrimaryGroup));
         playerPlaceholders.put("client_version", ofStringData(BungeeData.ClientVersion));
         playerPlaceholders.put("uuid", ofFunction(player -> player.getUniqueID().toString()));
         playerPlaceholders.put("world", ofStringData(MinecraftData.World));

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/playersorting/SortingRuleRegistry.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/playersorting/SortingRuleRegistry.java
@@ -52,6 +52,8 @@ public class SortingRuleRegistry {
             .put("vaultgroupinforeversed", new ReverseOrder(new VaultGroupInfo()))
             .put("bungeepermsgroupinfo", new BungeePermsGroupInfo())
             .put("bungeepermsgroupinforeversed", new ReverseOrder(new BungeePermsGroupInfo()))
+            .put("luckpermsgroupinfo", new LuckPermsGroupInfo())
+            .put("luckpermsgroupinforeversed", new ReverseOrder(new LuckPermsGroupInfo()))
             .put("bungeecordgroups", new BungeeCordGroups())
             .put("bungeecordgroupsreversed", new ReverseOrder(new BungeeCordGroups()))
             .put("vaultprefix", new VaultPrefixAlphabetically())

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/playersorting/rules/LuckPermsGroupInfo.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/playersorting/rules/LuckPermsGroupInfo.java
@@ -1,0 +1,52 @@
+/*
+ * BungeeTabListPlus - a BungeeCord plugin to customize the tablist
+ *
+ * Copyright (C) 2014 - 2015 Florian Stober
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package codecrafter47.bungeetablistplus.playersorting.rules;
+
+import de.codecrafter47.data.bungee.api.BungeeData;
+
+import codecrafter47.bungeetablistplus.api.bungee.IPlayer;
+import codecrafter47.bungeetablistplus.api.bungee.tablist.TabListContext;
+import codecrafter47.bungeetablistplus.context.Context;
+import codecrafter47.bungeetablistplus.player.Player;
+import codecrafter47.bungeetablistplus.playersorting.SortingRule;
+
+import java.util.Optional;
+
+public class LuckPermsGroupInfo implements SortingRule {
+    @Override
+    public int compare(TabListContext context, IPlayer player1, IPlayer player2) {
+        Optional<Integer> p1Weight = ((Player) player1).getOpt(BungeeData.LuckPerms_Weight);
+        Optional<Integer> p2Weight = ((Player) player2).getOpt(BungeeData.LuckPerms_Weight);
+        if (p1Weight.isPresent() || p2Weight.isPresent()) {
+            return p1Weight.orElse(Integer.MAX_VALUE) - p2Weight.orElse(Integer.MAX_VALUE);
+        }
+        return 0;
+    }
+
+    @Override
+    public int compare(Context context, IPlayer player1, IPlayer player2) {
+        Optional<Integer> p1Weight = ((Player) player1).getOpt(BungeeData.LuckPerms_Weight);
+        Optional<Integer> p2Weight = ((Player) player2).getOpt(BungeeData.LuckPerms_Weight);
+        if (p1Weight.isPresent() || p2Weight.isPresent()) {
+            return p1Weight.orElse(Integer.MAX_VALUE) - p2Weight.orElse(Integer.MAX_VALUE);
+        }
+        return 0;
+    }
+}

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/playersorting/rules/LuckPermsGroupInfo.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/playersorting/rules/LuckPermsGroupInfo.java
@@ -20,7 +20,6 @@
 package codecrafter47.bungeetablistplus.playersorting.rules;
 
 import de.codecrafter47.data.bungee.api.BungeeData;
-
 import codecrafter47.bungeetablistplus.api.bungee.IPlayer;
 import codecrafter47.bungeetablistplus.api.bungee.tablist.TabListContext;
 import codecrafter47.bungeetablistplus.context.Context;

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,6 @@
             <id>md_5-snapshots</id>
             <url>http://repo.md-5.net/content/repositories/snapshots/</url>
         </repository>
-        <repository>
-            <id>bungeeperms-repo</id>
-            <url>http://repo.wea-ondara.net/repository/public/</url>
-        </repository>
     </repositories>
 
     <build>


### PR DESCRIPTION
This PR adds support for pulling data from LuckPerms, as a follow on from CodeCrafter47/minecraft-data-api#1.

I have tested it locally and all seems to be working correctly.

### Changes made
1. Adds `LUCKPERMS` as a PermissionSource
2. Removes a number of redundant methods in PermissionManager (they're all set to package-private and are unused, looks like they've been replaced by the minecraft-data-api variables) Also removes the BungeePerms maven dependency, it wasn't being used.
3. Adds LuckPerms variable returns to PermissionManager. Where `BUNGEE` is selected, the existing behaviour to default to BungeePerms has been retained.
4. Adds LuckPerms placeholders to `BasicPlaceholders` and `Placeholder`
5. Adds `LuckPermsGroupInfo` to the SortingRuleRegistry. (as well as the reversed variant)