### PR TITLE
Add soft-dependency for SuperVanish and PremiumVanish

### DIFF
--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -3,4 +3,4 @@ main: codecrafter47.bungeetablistplus.BukkitPlugin
 version: ${project.version}
 authors:
   - CodeCrafter47
-softdepend: [Factions, Vault, VanishNoPacket, PlayerPoints, PlaceholderAPI]
+softdepend: [Factions, Vault, VanishNoPacket, SuperVanish, PremiumVanish, PlayerPoints, PlaceholderAPI]


### PR DESCRIPTION
Adds SV and PV(both plugins implement the SV API) as a soft-dependency to the plugin.yml of the bukkit bridge to fix a NoClassDefFoundError in the SuperVanish hook (#75)