### PR TITLE
1.13 bungeecord messaging channel rename

### DIFF
--- a/common/src/main/java/codecrafter47/bungeetablistplus/common/network/BridgeProtocolConstants.java
+++ b/common/src/main/java/codecrafter47/bungeetablistplus/common/network/BridgeProtocolConstants.java
@@ -23,7 +23,7 @@ package codecrafter47.bungeetablistplus.common.network;
  */
 public class BridgeProtocolConstants {
 
-    public static final String CHANNEL = "BTLP/Bridge";
+    public static final String CHANNEL = "btlp:bridge";
 
     public static final int VERSION = 5;
 


### PR DESCRIPTION
The messaging channel requires it to have a colon and lowercase letters. This should fix the startup issue for 1.13 users.