### PR TITLE
[Bungee] Change PlayerDisconnectEvent priority to LOWEST

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/listener/TabListListener.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/listener/TabListListener.java
@@ -51,7 +51,7 @@ public class TabListListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerDisconnect(PlayerDisconnectEvent e) {
         try {
             TabView tabView = btlp.getTabViewManager().onPlayerDisconnect(e.getPlayer());


### PR DESCRIPTION
Setting server to null could cause problems with other plugins. E.g. with auth, which stores player's latest server in database. It has normal priority and gets current server as 'null', because of BungeeTabListPlus. This PR changes priority to lowest, so other plugins get valid info about current server. 