### PR TITLE
Respect customServerOrder values when using yourserverfirst serverOrder option

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/config/PlayersByServerComponentConfiguration.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/config/PlayersByServerComponentConfiguration.java
@@ -238,7 +238,8 @@ public class PlayersByServerComponentConfiguration extends MarkedPropertyBase im
                         } else if (second.equals(server)) {
                             return 1;
                         } else {
-                            return 0;
+                            if(customServerOrder == null) return 0;
+                            return customServerOrder.getOrDefault(first, Integer.MAX_VALUE) - customServerOrder.getOrDefault(second, Integer.MAX_VALUE);
                         }
                     }
                 };


### PR DESCRIPTION
Currently it is not possible to use both custom sorting and `yourserverfirst` serverOrder.

This PR changes sorting to respect `customServerOrder` option (if present) to display all servers except the player's current in specified order while still displaying player's current on top.