### PR TITLE
Update ViaVersion dependency to 4.0.0

### DIFF
--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compileOnly "protocolsupport:ProtocolSupportBungee:1.3.dev"
     compileOnly "com.google.guava:guava:17.0"
     testImplementation "com.google.guava:guava:17.0"
-    compileOnly 'us.myles:viaversion:3.0.0'
+    compileOnly "com.viaversion:viaversion-api:4.0.0"
 }
 
 processResources {

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/version/ViaVersionProtocolVersionProvider.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/version/ViaVersionProtocolVersionProvider.java
@@ -17,9 +17,9 @@
 
 package codecrafter47.bungeetablistplus.version;
 
+import com.viaversion.viaversion.api.Via;
+import com.viaversion.viaversion.api.protocol.version.ProtocolVersion;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import us.myles.ViaVersion.api.Via;
-import us.myles.ViaVersion.api.protocol.ProtocolVersion;
 
 public class ViaVersionProtocolVersionProvider implements ProtocolVersionProvider {
 


### PR DESCRIPTION
Fixes #641, #640

~~... the ViaVersion repo is down at the moment, but I assume when you are awake/look at it, it should be online again (just check if you can reach https://repo.viaversion.com).~~ It's alive again.

The issue is due to the repackage, where a few old classes were kept for compatibility, but the old ProtocolVersion class does not contain the 1.17 protocol version, meaning the index you try to receive is -1.

A temporary solution was added in ViaVersion as well (adding 1.17 in the legacy ProtocolVersion class), but this is the "proper" fix here.