### PR TITLE
Fix submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "TabOverlayCommon"]
 	path = TabOverlayCommon
-	url = https://github.com/CodeCrafter47/TabOverlayCommon/
+	url = https://github.com/CodeCrafter47/TabOverlayCommon.git
 [submodule "minecraft-data-api"]
 	path = minecraft-data-api
-	url = https://github.com/CodeCrafter47/minecraft-data-api/
+	url = https://github.com/CodeCrafter47/minecraft-data-api.git


### PR DESCRIPTION
The current submodule URLs have a slash `/` appended to the URL instead of `.git`.

As a result, submodules don't work when git is configured to rewrite https connections to github to ssh.