### PR TITLE
Fix for Bungeecord protocol Changes, Maintaining backwards compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 ext {
     spigotVersion = '1.11-R0.1-SNAPSHOT'
-    bungeeVersion = '1.15-SNAPSHOT'
+    bungeeVersion = '1.19-R0.1-SNAPSHOT'
     spongeVersion = '7.0.0'
     dataApiVersion = '1.0.2-SNAPSHOT'
 }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractLegacyTabOverlayHandler.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractLegacyTabOverlayHandler.java
@@ -21,8 +21,10 @@ import codecrafter47.bungeetablistplus.protocol.PacketHandler;
 import codecrafter47.bungeetablistplus.protocol.PacketListenerResult;
 import codecrafter47.bungeetablistplus.util.ColorParser;
 import codecrafter47.bungeetablistplus.util.ConcurrentBitSet;
+import codecrafter47.bungeetablistplus.util.Property119Handler;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import de.codecrafter47.bungeetablistplus.bungee.compat.PropertyUtil;
 import de.codecrafter47.taboverlay.Icon;
 import de.codecrafter47.taboverlay.config.misc.ChatFormat;
 import de.codecrafter47.taboverlay.config.misc.Unchecked;
@@ -66,7 +68,18 @@ public abstract class AbstractLegacyTabOverlayHandler implements PacketHandler, 
 
     private static final Int2ObjectMap<Collection<RectangularTabOverlay.Dimension>> playerListSizeToSupportedSizesMap = new Int2ObjectOpenHashMap<>();
 
+
+    private static final boolean USE_PROTOCOL_PROPERTY_TYPE;
+
     static {
+        boolean classPresent = false;
+        try {
+            Class.forName("net.md_5.bungee.protocol.Property");
+            classPresent = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        USE_PROTOCOL_PROPERTY_TYPE = classPresent;
+
         // add a random character to the player and team names to prevent issues in multi-bungee setup (stupid!).
         int random = ThreadLocalRandom.current().nextInt(0x1e00, 0x2c00);
 
@@ -287,7 +300,9 @@ public abstract class AbstractLegacyTabOverlayHandler implements PacketHandler, 
                 item.setUsername(entry.getValue().name);
                 item.setGamemode(entry.getValue().gamemode);
                 item.setPing(entry.getValue().latency);
-                item.setProperties(EMPTY_PROPERTIES);
+                if(USE_PROTOCOL_PROPERTY_TYPE) {
+
+                }
                 pli.setItems(new PlayerListItem.Item[]{item});
                 pli.setAction(PlayerListItem.Action.ADD_PLAYER);
                 sendPacket(pli);
@@ -415,7 +430,11 @@ public abstract class AbstractLegacyTabOverlayHandler implements PacketHandler, 
             PlayerListItem.Item item = new PlayerListItem.Item();
             item.setUuid(slotUUID[index]);
             item.setUsername(slotID[index]);
-            item.setProperties(EMPTY_PROPERTIES);
+            if(USE_PROTOCOL_PROPERTY_TYPE) {
+                Property119Handler.setProperties(item, EMPTY_PROPERTIES);
+            } else {
+                PropertyUtil.setProperties(item, EMPTY_PROPERTIES);
+            }
             item.setDisplayName(slotID[index]);
             item.setPing(tabOverlay.ping[index]);
             pli.setItems(new PlayerListItem.Item[]{item});

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractLegacyTabOverlayHandler.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractLegacyTabOverlayHandler.java
@@ -301,7 +301,9 @@ public abstract class AbstractLegacyTabOverlayHandler implements PacketHandler, 
                 item.setGamemode(entry.getValue().gamemode);
                 item.setPing(entry.getValue().latency);
                 if(USE_PROTOCOL_PROPERTY_TYPE) {
-
+                    Property119Handler.setProperties(item, EMPTY_PROPERTIES);
+                } else {
+                    PropertyUtil.setProperties(item, EMPTY_PROPERTIES);
                 }
                 pli.setItems(new PlayerListItem.Item[]{item});
                 pli.setAction(PlayerListItem.Action.ADD_PLAYER);

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractTabOverlayHandler.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractTabOverlayHandler.java
@@ -21,6 +21,7 @@ import codecrafter47.bungeetablistplus.protocol.PacketHandler;
 import codecrafter47.bungeetablistplus.protocol.PacketListenerResult;
 import codecrafter47.bungeetablistplus.util.BitSet;
 import codecrafter47.bungeetablistplus.util.ConcurrentBitSet;
+import codecrafter47.bungeetablistplus.util.Property119Handler;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -40,8 +41,6 @@ import net.md_5.bungee.protocol.packet.Team;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
@@ -1044,9 +1043,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
                                 if(USE_PROTOCOL_PROPERTY_TYPE) {
-                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                    Property119Handler.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 } else {
-                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
@@ -1287,9 +1286,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                         item1.setUuid(customSlotUuid);
                         item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
                         if(USE_PROTOCOL_PROPERTY_TYPE) {
-                            PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                            Property119Handler.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                         } else {
-                            item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                            PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                         }
                         item1.setDisplayName(tabOverlay.text[index]);
                         item1.setPing(tabOverlay.ping[index]);
@@ -1575,9 +1574,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
                                 if(USE_PROTOCOL_PROPERTY_TYPE) {
-                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                    Property119Handler.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 } else {
-                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
@@ -1601,9 +1600,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
                                 if(USE_PROTOCOL_PROPERTY_TYPE) {
-                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                    Property119Handler.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 } else {
-                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
@@ -1645,7 +1644,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(CUSTOM_SLOT_UUID_SPACER[i]);
                                 item1.setUsername("");
-                                item1.setProperties(EMPTY_PROPERTIES_ARRAY);
+                                if(USE_PROTOCOL_PROPERTY_TYPE) {
+                                    Property119Handler.setProperties(item1, EMPTY_PROPERTIES_ARRAY);
+                                } else {
+                                    PropertyUtil.setProperties(item1, EMPTY_PROPERTIES_ARRAY);
+                                }
                                 item1.setDisplayName(null);
                                 item1.setPing(0);
                                 item1.setGamemode(0);
@@ -1968,9 +1971,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
                                 if(USE_PROTOCOL_PROPERTY_TYPE) {
-                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                    Property119Handler.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 } else {
-                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                                 }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
@@ -2012,9 +2015,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                     item1.setUuid(customSlotUuid);
                     item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
                     if(USE_PROTOCOL_PROPERTY_TYPE) {
-                        PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                        Property119Handler.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                     } else {
-                        item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                        PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
                     }
                     item1.setDisplayName(tabOverlay.text[index]);
                     item1.setPing(tabOverlay.ping[index]);
@@ -2654,9 +2657,9 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
         private PlayerListEntry(PlayerListItem.Item item) {
             this(item.getUuid(), null, item.getUsername(), item.getDisplayName(), item.getPing(), item.getGamemode());
             if(USE_PROTOCOL_PROPERTY_TYPE) {
-                properties = PropertyUtil.getProperties(item);
+                properties = Property119Handler.getProperties(item);
             } else {
-                properties = item.getProperties();
+                properties = PropertyUtil.getProperties(item);
             }
         }
     }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractTabOverlayHandler.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractTabOverlayHandler.java
@@ -64,6 +64,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
 
     private static final boolean TEAM_COLLISION_RULE_SUPPORTED;
     private static final boolean TEAM_COLOR_IS_BYTE;
+    private static final boolean USE_PROTOCOL_PROPERTY_TYPE;
 
     private static final ImmutableMap<RectangularTabOverlay.Dimension, BitSet> DIMENSION_TO_USED_SLOTS;
     private static final BitSet[] SIZE_TO_USED_SLOTS;
@@ -100,6 +101,14 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
         } catch (NoSuchMethodException ignored) {
         }
         TEAM_COLOR_IS_BYTE = methodPresent;
+
+        methodPresent = false;
+        try {
+            Class.forName("net.md_5.bungee.protocol.Property");
+            methodPresent = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        USE_PROTOCOL_PROPERTY_TYPE = methodPresent;
 
         // build the dimension to used slots map (for the rectangular tab overlay)
         val builder = ImmutableMap.<RectangularTabOverlay.Dimension, BitSet>builder();
@@ -1034,7 +1043,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
+                                if(USE_PROTOCOL_PROPERTY_TYPE) {
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                } else {
+                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1273,7 +1286,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                         PlayerListItem.Item item1 = new PlayerListItem.Item();
                         item1.setUuid(customSlotUuid);
                         item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                        PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
+                        if(USE_PROTOCOL_PROPERTY_TYPE) {
+                            PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                        } else {
+                            item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                        }
                         item1.setDisplayName(tabOverlay.text[index]);
                         item1.setPing(tabOverlay.ping[index]);
                         item1.setGamemode(0);
@@ -1557,7 +1574,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
+                                if(USE_PROTOCOL_PROPERTY_TYPE) {
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                } else {
+                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1579,7 +1600,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
+                                if(USE_PROTOCOL_PROPERTY_TYPE) {
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                } else {
+                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1942,7 +1967,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
+                                if(USE_PROTOCOL_PROPERTY_TYPE) {
+                                    PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                                } else {
+                                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                }
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1982,7 +2011,11 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                     PlayerListItem.Item item1 = new PlayerListItem.Item();
                     item1.setUuid(customSlotUuid);
                     item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                    PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
+                    if(USE_PROTOCOL_PROPERTY_TYPE) {
+                        PropertyUtil.setProperties(item1, toPropertiesArray(icon.getTextureProperty()));
+                    } else {
+                        item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                    }
                     item1.setDisplayName(tabOverlay.text[index]);
                     item1.setPing(tabOverlay.ping[index]);
                     item1.setGamemode(0);
@@ -2619,7 +2652,12 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
         private int gamemode;
 
         private PlayerListEntry(PlayerListItem.Item item) {
-            this(item.getUuid(), PropertyUtil.getProperties(item), item.getUsername(), item.getDisplayName(), item.getPing(), item.getGamemode());
+            this(item.getUuid(), null, item.getUsername(), item.getDisplayName(), item.getPing(), item.getGamemode());
+            if(USE_PROTOCOL_PROPERTY_TYPE) {
+                properties = PropertyUtil.getProperties(item);
+            } else {
+                properties = item.getProperties();
+            }
         }
     }
 

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractTabOverlayHandler.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/AbstractTabOverlayHandler.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import de.codecrafter47.bungeetablistplus.bungee.compat.PacketUtil;
+import de.codecrafter47.bungeetablistplus.bungee.compat.PropertyUtil;
 import de.codecrafter47.taboverlay.Icon;
 import de.codecrafter47.taboverlay.ProfileProperty;
 import de.codecrafter47.taboverlay.config.misc.ChatFormat;
@@ -39,6 +40,8 @@ import net.md_5.bungee.protocol.packet.Team;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
@@ -1031,7 +1034,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1270,7 +1273,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                         PlayerListItem.Item item1 = new PlayerListItem.Item();
                         item1.setUuid(customSlotUuid);
                         item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                        item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                        PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
                         item1.setDisplayName(tabOverlay.text[index]);
                         item1.setPing(tabOverlay.ping[index]);
                         item1.setGamemode(0);
@@ -1554,7 +1557,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1576,7 +1579,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1939,7 +1942,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                                 PlayerListItem.Item item1 = new PlayerListItem.Item();
                                 item1.setUuid(customSlotUuid);
                                 item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                                item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                                PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
                                 item1.setDisplayName(tabOverlay.text[index]);
                                 item1.setPing(tabOverlay.ping[index]);
                                 item1.setGamemode(0);
@@ -1979,7 +1982,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
                     PlayerListItem.Item item1 = new PlayerListItem.Item();
                     item1.setUuid(customSlotUuid);
                     item1.setUsername(slotUsername[index] = getCustomSlotUsername(index));
-                    item1.setProperties(toPropertiesArray(icon.getTextureProperty()));
+                    PropertyUtil.safelySetProperties(toPropertiesArray(icon.getTextureProperty()), item1);
                     item1.setDisplayName(tabOverlay.text[index]);
                     item1.setPing(tabOverlay.ping[index]);
                     item1.setGamemode(0);
@@ -2616,7 +2619,7 @@ public abstract class AbstractTabOverlayHandler implements PacketHandler, TabOve
         private int gamemode;
 
         private PlayerListEntry(PlayerListItem.Item item) {
-            this(item.getUuid(), item.getProperties(), item.getUsername(), item.getDisplayName(), item.getPing(), item.getGamemode());
+            this(item.getUuid(), PropertyUtil.getProperties(item), item.getUsername(), item.getDisplayName(), item.getPing(), item.getGamemode());
         }
     }
 

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/RewriteLogic.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/handler/RewriteLogic.java
@@ -20,7 +20,9 @@ package codecrafter47.bungeetablistplus.handler;
 import codecrafter47.bungeetablistplus.protocol.AbstractPacketHandler;
 import codecrafter47.bungeetablistplus.protocol.PacketHandler;
 import codecrafter47.bungeetablistplus.protocol.PacketListenerResult;
+import codecrafter47.bungeetablistplus.util.Property119Handler;
 import com.google.common.base.MoreObjects;
+import de.codecrafter47.bungeetablistplus.bungee.compat.PropertyUtil;
 import net.md_5.bungee.BungeeCord;
 import net.md_5.bungee.UserConnection;
 import net.md_5.bungee.connection.LoginResult;
@@ -31,6 +33,18 @@ import java.util.Map;
 import java.util.UUID;
 
 public class RewriteLogic extends AbstractPacketHandler {
+
+    private static final boolean USE_PROTOCOL_PROPERTY_TYPE;
+
+    static {
+        boolean classPresent = false;
+        try {
+            Class.forName("net.md_5.bungee.protocol.Property");
+            classPresent = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        USE_PROTOCOL_PROPERTY_TYPE = classPresent;
+    }
 
     private final Map<UUID, UUID> rewriteMap = new HashMap<>();
 
@@ -69,18 +83,12 @@ public class RewriteLogic extends AbstractPacketHandler {
                         if (player != null) {
                             LoginResult loginResult = player.getPendingConnection().getLoginProfile();
                             if (loginResult != null) {
-                                LoginResult.Property[] properties = loginResult.getProperties();
-                                if (properties != null) {
-                                    String[][] props = new String[properties.length][];
-                                    for (int i = 0; i < props.length; i++) {
-                                        props[i] = new String[]
-                                                {
-                                                        properties[i].getName(),
-                                                        properties[i].getValue(),
-                                                        properties[i].getSignature()
-                                                };
-                                    }
-                                    item.setProperties(props);
+                                if(USE_PROTOCOL_PROPERTY_TYPE) {
+                                    String[][] properties = Property119Handler.getProperties(loginResult);
+                                    Property119Handler.setProperties(item, properties);
+                                } else {
+                                    String[][] properties = PropertyUtil.getProperties(loginResult);
+                                    PropertyUtil.setProperties(item, properties);
                                 }
                             }
                         }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/util/IconUtil.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/util/IconUtil.java
@@ -26,7 +26,6 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.connection.LoginResult;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 
 @UtilityClass
 public class IconUtil {
@@ -66,9 +65,9 @@ public class IconUtil {
         if (loginResult != null) {
             String[][] properties;
             if(USE_PROTOCOL_PROPERTY_TYPE) {
-                properties = PropertyUtil.getProperties(loginResult);
+                properties = Property119Handler.getProperties(loginResult);
             } else {
-                properties = Arrays.stream(loginResult.getProperties()).map(prop -> new String[]{prop.getName(), prop.getValue(), prop.getSignature()}).toArray(String[][]::new);
+                properties = PropertyUtil.getProperties(loginResult);
             }
             if (properties.length != 0) {
                 for (String[] s : properties) {

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/util/IconUtil.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/util/IconUtil.java
@@ -17,6 +17,7 @@
 
 package codecrafter47.bungeetablistplus.util;
 
+import de.codecrafter47.bungeetablistplus.bungee.compat.PropertyUtil;
 import de.codecrafter47.taboverlay.Icon;
 import de.codecrafter47.taboverlay.ProfileProperty;
 import lombok.experimental.UtilityClass;
@@ -50,9 +51,9 @@ public class IconUtil {
     public Icon getIconFromPlayer(ProxiedPlayer player) {
         LoginResult loginResult = ((UserConnection) player).getPendingConnection().getLoginProfile();
         if (loginResult != null) {
-            LoginResult.Property[] properties = loginResult.getProperties();
+            PropertyUtil.VersionSafeProperty[] properties = PropertyUtil.convertLoginProperties(loginResult);
             if (properties != null) {
-                for (LoginResult.Property s : properties) {
+                for (PropertyUtil.VersionSafeProperty s : properties) {
                     if (s.getName().equals("textures")) {
                         return new Icon(new ProfileProperty(s.getName(), s.getValue(), s.getSignature()));
                     }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/util/IconUtil.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/util/IconUtil.java
@@ -26,9 +26,22 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.connection.LoginResult;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 
 @UtilityClass
 public class IconUtil {
+
+    private static final boolean USE_PROTOCOL_PROPERTY_TYPE;
+
+    static {
+        boolean classPresent = false;
+        try {
+            Class.forName("net.md_5.bungee.protocol.Property");
+            classPresent = true;
+        } catch (ClassNotFoundException ignored) {
+        }
+        USE_PROTOCOL_PROPERTY_TYPE = classPresent;
+    }
 
     public Icon convert(codecrafter47.bungeetablistplus.api.bungee.Icon icon) {
         String[][] properties = icon.getProperties();
@@ -51,11 +64,16 @@ public class IconUtil {
     public Icon getIconFromPlayer(ProxiedPlayer player) {
         LoginResult loginResult = ((UserConnection) player).getPendingConnection().getLoginProfile();
         if (loginResult != null) {
-            PropertyUtil.VersionSafeProperty[] properties = PropertyUtil.convertLoginProperties(loginResult);
-            if (properties != null) {
-                for (PropertyUtil.VersionSafeProperty s : properties) {
-                    if (s.getName().equals("textures")) {
-                        return new Icon(new ProfileProperty(s.getName(), s.getValue(), s.getSignature()));
+            String[][] properties;
+            if(USE_PROTOCOL_PROPERTY_TYPE) {
+                properties = PropertyUtil.getProperties(loginResult);
+            } else {
+                properties = Arrays.stream(loginResult.getProperties()).map(prop -> new String[]{prop.getName(), prop.getValue(), prop.getSignature()}).toArray(String[][]::new);
+            }
+            if (properties.length != 0) {
+                for (String[] s : properties) {
+                    if (s[0].equals("textures")) {
+                        return new Icon(new ProfileProperty(s[0], s[1], s[2]));
                     }
                 }
             }

--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/util/Property119Handler.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/util/Property119Handler.java
@@ -1,13 +1,14 @@
-package de.codecrafter47.bungeetablistplus.bungee.compat;
+package codecrafter47.bungeetablistplus.util;
 
 import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.protocol.Property;
 import net.md_5.bungee.protocol.packet.PlayerListItem;
 
 import java.util.Arrays;
 
-public class PropertyUtil {
+public class Property119Handler {
     public static String[][] getProperties(PlayerListItem.Item item) {
-        return item.getProperties();
+        return Arrays.stream(item.getProperties()).map(prop -> new String[]{prop.getName(), prop.getValue(), prop.getSignature()}).toArray(String[][]::new);
     }
 
     public static String[][] getProperties(LoginResult loginResult) {
@@ -15,6 +16,6 @@ public class PropertyUtil {
     }
 
     public static void setProperties(PlayerListItem.Item item, String[][] properties) {
-        item.setProperties(properties);
+        item.setProperties(Arrays.stream(properties).map(array -> new Property(array[0], array[1], array.length >= 3 ? array[2] : null)).toArray(Property[]::new));
     }
 }

--- a/bungee/src/test/java/codecrafter47/bungeetablistplus/tablisthandler/logic/AbstractTabListLogicTest.java
+++ b/bungee/src/test/java/codecrafter47/bungeetablistplus/tablisthandler/logic/AbstractTabListLogicTest.java
@@ -18,6 +18,7 @@
 package codecrafter47.bungeetablistplus.tablisthandler.logic;
 
 import codecrafter47.bungeetablistplus.api.bungee.Icon;
+import codecrafter47.bungeetablistplus.util.Property119Handler;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -136,7 +137,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
                     item.setUsername(usernames[p]);
                     item.setUuid(uuids[p]);
                     item.setPing(p + 13);
-                    item.setProperties(new String[0][]);
+                    Property119Handler.setProperties(item, new String[0][]);
                     item.setGamemode(p % 4);
                     packet.setItems(new PlayerListItem.Item[]{item});
                     tabListHandler.onPlayerListPacket(packet);
@@ -188,7 +189,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(3);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -250,7 +251,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(3);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -278,7 +279,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -306,7 +307,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(3);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -339,7 +340,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[4]);
         item.setUuid(uuids[4]);
         item.setPing(4);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(3);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -367,7 +368,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[4]);
         item.setUuid(uuids[4]);
         item.setPing(4);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -395,7 +396,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[4]);
         item.setUuid(uuids[4]);
         item.setPing(4);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(3);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -421,7 +422,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -443,7 +444,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -463,7 +464,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -490,7 +491,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -523,7 +524,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -563,7 +564,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -603,7 +604,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(uuids[47]);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -645,7 +646,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
             item.setUsername(usernames[i]);
             item.setUuid(uuids[i]);
             item.setPing(15);
-            item.setProperties(new String[0][]);
+            Property119Handler.setProperties(item, new String[0][]);
             item.setGamemode(0);
             items[i] = item;
 
@@ -797,7 +798,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
             item.setUsername(usernames[i]);
             item.setUuid(uuids[i]);
             item.setPing(15);
-            item.setProperties(new String[0][]);
+            Property119Handler.setProperties(item, new String[0][]);
             item.setGamemode(0);
             items[i] = item;
 
@@ -856,7 +857,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
             item.setUsername(usernames[i]);
             item.setUuid(uuids[i]);
             item.setPing(15);
-            item.setProperties(new String[0][]);
+            Property119Handler.setProperties(item, new String[0][]);
             item.setGamemode(0);
             items[i] = item;
 
@@ -906,7 +907,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(clientUUID);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(3);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);
@@ -930,7 +931,7 @@ public class AbstractTabListLogicTest extends AbstractTabListLogicTestBase {
         item.setUsername(usernames[47]);
         item.setUuid(clientUUID);
         item.setPing(47);
-        item.setProperties(new String[0][]);
+        Property119Handler.setProperties(item, new String[0][]);
         item.setGamemode(0);
         packet.setItems(new PlayerListItem.Item[]{item});
         tabListHandler.onPlayerListPacket(packet);

--- a/bungee_compat/build.gradle
+++ b/bungee_compat/build.gradle
@@ -1,5 +1,6 @@
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    compileOnly 'net.md-5:bungeecord-protocol:1.12-SNAPSHOT'
+    compileOnly 'net.md-5:bungeecord-protocol:1.19-R0.1-SNAPSHOT'
+    compileOnly 'net.md-5:bungeecord-proxy:1.19-R0.1-SNAPSHOT'
 }

--- a/bungee_compat/build.gradle
+++ b/bungee_compat/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    compileOnly 'net.md-5:bungeecord-protocol:1.19-R0.1-SNAPSHOT'
-    compileOnly 'net.md-5:bungeecord-proxy:1.19-R0.1-SNAPSHOT'
+    compileOnly 'net.md-5:bungeecord-protocol:1.12-SNAPSHOT'
+    compileOnly 'net.md-5:bungeecord-proxy:1.12-SNAPSHOT'
 }

--- a/bungee_compat/src/main/java/de/codecrafter47/bungeetablistplus/bungee/compat/PacketUtil.java
+++ b/bungee_compat/src/main/java/de/codecrafter47/bungeetablistplus/bungee/compat/PacketUtil.java
@@ -36,6 +36,6 @@ public final class PacketUtil {
     }
 
     public static byte getTeamColorByte(final Team team) {
-        return team.getColor();
+        return (byte) team.getColor();
     }
 }

--- a/bungee_compat/src/main/java/de/codecrafter47/bungeetablistplus/bungee/compat/PropertyUtil.java
+++ b/bungee_compat/src/main/java/de/codecrafter47/bungeetablistplus/bungee/compat/PropertyUtil.java
@@ -1,0 +1,126 @@
+package de.codecrafter47.bungeetablistplus.bungee.compat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class PropertyUtil {
+
+    /**
+     * Used to safely get the property arrays from objects that used to return String[][] properties and now do Property[]
+     * @param object object to get properties from, should implement a getProperties() method
+     * @return String[][] array of properties, as seen in >=1.18
+     */
+    public static String[][] getProperties(Object object) {
+        try {
+            Method getProperties = object.getClass().getMethod("getProperties");
+            Object properties = getProperties.invoke(object); //Get using reflection to not lock return type
+            if(properties instanceof String[][]) {
+                //Pre 1.19, just return value
+                return (String[][]) properties;
+            } else if(bungeeProtocolPropertyClass().isPresent()) {
+                //Post 1.19, convert property class using reflection to keep backwards compat
+                Object[] propertiesObjects = (Object[]) properties;
+                String[][] newProperties = new String[propertiesObjects.length][3];
+                for (int i = 0; i < propertiesObjects.length; i++) {
+                    Object p = propertiesObjects[i];
+                    newProperties[i] = VersionSafeProperty.makeFrom(p, bungeeProtocolPropertyClass().get()).toArray();
+                }
+                return newProperties;
+            } else {
+                throw new RuntimeException("Unsupported Version!");
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Used to convert the LoginResult.Property or protocol.Property to a version safe equivalent
+     * @param propertyHolder object implementing getProperties(), returning either LoginResult.Property[] or protocol.Property[]
+     * @return Version safe equivalent
+     */
+    public static VersionSafeProperty[] convertLoginProperties(Object propertyHolder) {
+        try {
+            Method getProperties = propertyHolder.getClass().getMethod("getProperties");
+            Object propertiesOrNull = getProperties.invoke(propertyHolder); //Get using reflection to not lock return type
+            if(propertiesOrNull == null) return null;
+            Object[] properties = (Object[]) propertiesOrNull;
+            VersionSafeProperty[] vsProps = new VersionSafeProperty[properties.length];
+            for (int i = 0; i < properties.length; i++) {
+                vsProps[i] = VersionSafeProperty.makeFrom(properties[i], getProperties.getReturnType().getComponentType());
+            }
+            return vsProps;
+        } catch(ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Sets the property of an object with either a setProperties(String[][]) or setProperties(Property[]) method
+     * @param properties 1.18-style property array
+     * @param object object implementing either setProperties(String[][]) or setProperties(Property[])
+     */
+    public static void safelySetProperties(String[][] properties, Object object) {
+        try {
+            if (bungeeProtocolPropertyClass().isPresent()) {
+                Class<?> bungeeProtocolPropertyClass = bungeeProtocolPropertyClass().get();
+                Object[] newPropArray = (Object[]) Array.newInstance(bungeeProtocolPropertyClass, properties.length);
+                for (int i = 0; i < properties.length; i++) {
+                    newPropArray[i] = new VersionSafeProperty(properties[i]).convertTo(bungeeProtocolPropertyClass);
+                }
+
+                Method setPropertyMethod = object.getClass().getMethod("setProperties", newPropArray.getClass());
+                setPropertyMethod.invoke(object, (Object) newPropArray);
+            } else {
+                Method setPropertyMethod = object.getClass().getMethod("setProperties", String[][].class);
+                setPropertyMethod.invoke(object, (Object) properties);
+            }
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<Class<?>> bungeeProtocolPropertyClass() {
+        try {
+            return Optional.of(Class.forName("net.md_5.bungee.protocol.Property"));
+        } catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class VersionSafeProperty
+    {
+        private String name;
+        private String value;
+        private String signature;
+
+        private static VersionSafeProperty makeFrom(Object property, Class<?> propertyClass) throws ReflectiveOperationException {
+            Method nameMethod = propertyClass.getDeclaredMethod("getName");
+            Method valueMethod = propertyClass.getDeclaredMethod("getValue");
+            Method sigMethod = propertyClass.getDeclaredMethod("getSignature");
+
+            return new VersionSafeProperty((String) nameMethod.invoke(property), (String) valueMethod.invoke(property), (String) sigMethod.invoke(property));
+        }
+
+        private VersionSafeProperty (String[] properties) {
+            this(properties[0], properties[1], properties.length >= 3 ? properties[2] : null);
+        }
+
+        public String[] toArray() {
+            return new String[]{name, value, signature};
+        }
+
+        private Object convertTo(Class<?> clazz) throws ReflectiveOperationException{
+            Constructor<?> constructor = clazz.getDeclaredConstructor(String.class, String.class, String.class);
+            return constructor.newInstance(name, value, signature);
+        }
+    }
+}

--- a/bungee_compat/src/main/java/de/codecrafter47/bungeetablistplus/bungee/compat/PropertyUtil.java
+++ b/bungee_compat/src/main/java/de/codecrafter47/bungeetablistplus/bungee/compat/PropertyUtil.java
@@ -1,126 +1,21 @@
 package de.codecrafter47.bungeetablistplus.bungee.compat;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import net.md_5.bungee.connection.LoginResult;
+import net.md_5.bungee.protocol.Property;
+import net.md_5.bungee.protocol.packet.PlayerListItem;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Optional;
+import java.util.Arrays;
 
 public class PropertyUtil {
-
-    /**
-     * Used to safely get the property arrays from objects that used to return String[][] properties and now do Property[]
-     * @param object object to get properties from, should implement a getProperties() method
-     * @return String[][] array of properties, as seen in >=1.18
-     */
-    public static String[][] getProperties(Object object) {
-        try {
-            Method getProperties = object.getClass().getMethod("getProperties");
-            Object properties = getProperties.invoke(object); //Get using reflection to not lock return type
-            if(properties instanceof String[][]) {
-                //Pre 1.19, just return value
-                return (String[][]) properties;
-            } else if(bungeeProtocolPropertyClass().isPresent()) {
-                //Post 1.19, convert property class using reflection to keep backwards compat
-                Object[] propertiesObjects = (Object[]) properties;
-                String[][] newProperties = new String[propertiesObjects.length][3];
-                for (int i = 0; i < propertiesObjects.length; i++) {
-                    Object p = propertiesObjects[i];
-                    newProperties[i] = VersionSafeProperty.makeFrom(p, bungeeProtocolPropertyClass().get()).toArray();
-                }
-                return newProperties;
-            } else {
-                throw new RuntimeException("Unsupported Version!");
-            }
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
+    public static String[][] getProperties(PlayerListItem.Item item) {
+        return Arrays.stream(item.getProperties()).map(prop -> new String[]{prop.getName(), prop.getValue(), prop.getSignature()}).toArray(String[][]::new);
     }
 
-    /**
-     * Used to convert the LoginResult.Property or protocol.Property to a version safe equivalent
-     * @param propertyHolder object implementing getProperties(), returning either LoginResult.Property[] or protocol.Property[]
-     * @return Version safe equivalent
-     */
-    public static VersionSafeProperty[] convertLoginProperties(Object propertyHolder) {
-        try {
-            Method getProperties = propertyHolder.getClass().getMethod("getProperties");
-            Object propertiesOrNull = getProperties.invoke(propertyHolder); //Get using reflection to not lock return type
-            if(propertiesOrNull == null) return null;
-            Object[] properties = (Object[]) propertiesOrNull;
-            VersionSafeProperty[] vsProps = new VersionSafeProperty[properties.length];
-            for (int i = 0; i < properties.length; i++) {
-                vsProps[i] = VersionSafeProperty.makeFrom(properties[i], getProperties.getReturnType().getComponentType());
-            }
-            return vsProps;
-        } catch(ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
+    public static String[][] getProperties(LoginResult loginResult) {
+        return Arrays.stream(loginResult.getProperties()).map(prop -> new String[]{prop.getName(), prop.getValue(), prop.getSignature()}).toArray(String[][]::new);
     }
 
-    /**
-     * Sets the property of an object with either a setProperties(String[][]) or setProperties(Property[]) method
-     * @param properties 1.18-style property array
-     * @param object object implementing either setProperties(String[][]) or setProperties(Property[])
-     */
-    public static void safelySetProperties(String[][] properties, Object object) {
-        try {
-            if (bungeeProtocolPropertyClass().isPresent()) {
-                Class<?> bungeeProtocolPropertyClass = bungeeProtocolPropertyClass().get();
-                Object[] newPropArray = (Object[]) Array.newInstance(bungeeProtocolPropertyClass, properties.length);
-                for (int i = 0; i < properties.length; i++) {
-                    newPropArray[i] = new VersionSafeProperty(properties[i]).convertTo(bungeeProtocolPropertyClass);
-                }
-
-                Method setPropertyMethod = object.getClass().getMethod("setProperties", newPropArray.getClass());
-                setPropertyMethod.invoke(object, (Object) newPropArray);
-            } else {
-                Method setPropertyMethod = object.getClass().getMethod("setProperties", String[][].class);
-                setPropertyMethod.invoke(object, (Object) properties);
-            }
-        } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static Optional<Class<?>> bungeeProtocolPropertyClass() {
-        try {
-            return Optional.of(Class.forName("net.md_5.bungee.protocol.Property"));
-        } catch (ClassNotFoundException e) {
-            return Optional.empty();
-        }
-    }
-
-    @Data
-    @AllArgsConstructor
-    public static class VersionSafeProperty
-    {
-        private String name;
-        private String value;
-        private String signature;
-
-        private static VersionSafeProperty makeFrom(Object property, Class<?> propertyClass) throws ReflectiveOperationException {
-            Method nameMethod = propertyClass.getDeclaredMethod("getName");
-            Method valueMethod = propertyClass.getDeclaredMethod("getValue");
-            Method sigMethod = propertyClass.getDeclaredMethod("getSignature");
-
-            return new VersionSafeProperty((String) nameMethod.invoke(property), (String) valueMethod.invoke(property), (String) sigMethod.invoke(property));
-        }
-
-        private VersionSafeProperty (String[] properties) {
-            this(properties[0], properties[1], properties.length >= 3 ? properties[2] : null);
-        }
-
-        public String[] toArray() {
-            return new String[]{name, value, signature};
-        }
-
-        private Object convertTo(Class<?> clazz) throws ReflectiveOperationException{
-            Constructor<?> constructor = clazz.getDeclaredConstructor(String.class, String.class, String.class);
-            return constructor.newInstance(name, value, signature);
-        }
+    public static void setProperties(PlayerListItem.Item item, String[][] properties) {
+        item.setProperties(Arrays.stream(properties).map(array -> new Property(array[0], array[1], array.length >= 3 ? array[2] : null)).toArray(Property[]::new));
     }
 }


### PR DESCRIPTION
In the newest update of bungeecord (and consequently waterfall), the packet format changed slightly, with `PlayerListItem.Item` now using a new class "Property" array, instead of the 2D properties array like before. This PR adds support for that while maintaining backward compatibility using reflection magic. 

This fixes #677 