### PR TITLE
Fixed NPE in bungee custom tab list

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/tablist/DefaultCustomTablist.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/tablist/DefaultCustomTablist.java
@@ -123,18 +123,24 @@ public class DefaultCustomTablist extends AbstractCustomTablist {
 
         void onSizeChanged() {
             synchronized (DefaultCustomTablist.this) {
-                int size = getSize();
-                tabOverlay.setSize(size);
-                updateAllSlots();
+                if (tabOverlay != null) {
+                    int size = getSize();
+                    tabOverlay.setSize(size);
+                    updateAllSlots();
+                }
             }
         }
 
         void onSlotChanged(int index, Icon icon, String text, int ping) {
-            tabOverlay.setSlot(index, icon, text, ping);
+            if (tabOverlay != null) {
+                tabOverlay.setSlot(index, icon, text, ping);
+            }
         }
 
         void setHeaderFooter(String header, String footer) {
-            headerAndFooterHandle.setHeaderFooter(header, footer);
+            if (headerAndFooterHandle != null) {
+                headerAndFooterHandle.setHeaderFooter(header, footer);
+            }
         }
     }
 }


### PR DESCRIPTION
When using a custom tab list in bungee, in the following scenario, there is a small chance to generate a NPE when the user logs in _(even more if he has bad internet and takes a while to join)_.

- Generate the tab list on a repeating task (e.g 5 seconds)
- Add / Remove players from the plugin on post login / disconnect event

When adding a new player, this code is called asynchronously https://github.com/CodeCrafter47/TabOverlayCommon/blob/master/src/main/java/de/codecrafter47/taboverlay/TabOverlayProviderSet.java#L126 _(`attach()` is what adds the provider to the tablist)_, and if the tablist is generated before `update()` is finished, the `tabOverlay` in the provider might be null, since `activate()` isn't called yet.

_(I know this part of the code is now deprecated, but I felt like it could still be worth fixing. We're still using it for an event server and when we have 500+ players online, it's very easy to reproduce it.)_