### PR TITLE
Add support for Player locale placeholder

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/PlayerPlaceholderResolver.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/placeholder/PlayerPlaceholderResolver.java
@@ -140,6 +140,7 @@ public class PlayerPlaceholderResolver extends AbstractPlayerPlaceholderResolver
         addPlaceholder("session_duration_total_seconds", create(BungeeData.BungeeCord_SessionDuration, duration -> duration == null ? null : (int) duration.getSeconds(), TypeToken.INTEGER));
         addPlaceholder("session_duration_minutes", create(BungeeData.BungeeCord_SessionDuration, duration -> duration == null ? null : (int) ((duration.getSeconds() % 3600) / 60), TypeToken.INTEGER));
         addPlaceholder("session_duration_hours", create(BungeeData.BungeeCord_SessionDuration, duration -> duration == null ? null : (int) (duration.getSeconds() / 3600), TypeToken.INTEGER));
+        addPlaceholder("locale", create(BungeeData.BungeeCord_Locale));
         addPlaceholder("essentials_afk", create(BukkitData.Essentials_IsAFK));
         addPlaceholder("is_hidden", create(BTLPBungeeDataKeys.DATA_KEY_IS_HIDDEN));
         addPlaceholder("gamemode", create(BTLPBungeeDataKeys.DATA_KEY_GAMEMODE));


### PR DESCRIPTION
Depends on https://github.com/CodeCrafter47/minecraft-data-api/pull/8

*Should* add a new placeholder `${player|viewer locale}` to get the locale of the player.

Had to update my locale submodule info to use my forks as remotes, so I didn't include them in this PR.