### PR TITLE
fix(velocity): cancel modified packets

### DIFF
--- a/velocity/src/main/java/codecrafter47/bungeetablistplus/protocol/PacketListener.java
+++ b/velocity/src/main/java/codecrafter47/bungeetablistplus/protocol/PacketListener.java
@@ -51,29 +51,24 @@ public class PacketListener extends MessageToMessageDecoder<MinecraftPacket> {
                 if (packet != null) {
 
                     PacketListenerResult result = PacketListenerResult.PASS;
-                    boolean handled = false;
 
                     if (packet instanceof Team) {
                         result = handler.onTeamPacket((Team) packet);
+                    } else if (packet instanceof LegacyPlayerListItemPacket) {
+                        result = handler.onPlayerListPacket((LegacyPlayerListItemPacket) packet);
+                    } else if (packet instanceof HeaderAndFooterPacket) {
+                        result = handler.onPlayerListHeaderFooterPacket((HeaderAndFooterPacket) packet);
+                    } else if (packet instanceof UpsertPlayerInfoPacket) {
+                        result = handler.onPlayerListUpdatePacket((UpsertPlayerInfoPacket) packet);
+                    } else if (packet instanceof RemovePlayerInfoPacket) {
+                        result = handler.onPlayerListRemovePacket((RemovePlayerInfoPacket) packet);
+                    }
+
+                    if (result != PacketListenerResult.PASS) {
                         if (result == PacketListenerResult.MODIFIED) {
                             sendPacket(player, packet);
                         }
-                    } else if (packet instanceof LegacyPlayerListItemPacket) {
-                        result = handler.onPlayerListPacket((LegacyPlayerListItemPacket) packet);
-                        handled = true;
-                    } else if (packet instanceof HeaderAndFooterPacket) {
-                        result = handler.onPlayerListHeaderFooterPacket((HeaderAndFooterPacket) packet);
-                        handled = true;
-                    } else if (packet instanceof UpsertPlayerInfoPacket) {
-                        result = handler.onPlayerListUpdatePacket((UpsertPlayerInfoPacket) packet);
-                        handled = true;
-                    } else if (packet instanceof RemovePlayerInfoPacket) {
-                        result = handler.onPlayerListRemovePacket((RemovePlayerInfoPacket) packet);
-                        handled = true;
-                    }
-
-                    if (handled && result != PacketListenerResult.CANCEL) {
-                        sendPacket(player, packet);
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
The velocity `PacketListener` was not cancelling packets that were being modified by BTLP, leading to what I assume are a number of issues, but most notably players being invisible when they move into render distance.

I took a look at the Bungeecord equivalent for this class, and saw [some logic](https://github.com/CodeCrafter47/BungeeTabListPlus/blob/master/bungee/src/main/java/codecrafter47/bungeetablistplus/protocol/PacketListener.java#L73-L77) absent from the velocity implementation on if the the packet should be cancelled, modified, or passed. In my testing, adding this into the velocity listener fixes the issue (though this was limited to my use case, ordered dynamic tab list, backend server handling scoreboard teams). I would be interested in if @proferabg had a reason for removing it in #766, or if this was just missed in the port.

I also took the chance to clean up this code a bit, as `result` should be reliable for determining if a modified packet should be sent, cancelled, or passed.

Also updating `minecraft-data-api` to include https://github.com/CodeCrafter47/minecraft-data-api/pull/10, let me know if you want this is a separate PR.