### PR TITLE
Velocity 1.21.9-1.21.10 + remove ProtocolVanish support

### DIFF
--- a/bungee/src/main/java/codecrafter47/bungeetablistplus/BungeeTabListPlus.java
+++ b/bungee/src/main/java/codecrafter47/bungeetablistplus/BungeeTabListPlus.java
@@ -290,7 +290,6 @@ public class BungeeTabListPlus {
         hiddenPlayersManager.addVanishProvider("CMI", BukkitData.CMI_IsVanished);
         hiddenPlayersManager.addVanishProvider("Essentials", BukkitData.Essentials_IsVanished);
         hiddenPlayersManager.addVanishProvider("ProxySuite", BungeeData.ProxyCore_IsHidden);
-        hiddenPlayersManager.addVanishProvider("ProtocolVanish", BukkitData.ProtocolVanish_IsVanished);
         hiddenPlayersManager.addVanishProvider("Bukkit Player Metadata `vanished`", BukkitData.BukkitPlayerMetadataVanished);
         hiddenPlayersManager.addVanishProvider("Sponge VANISH", SpongeData.Sponge_IsVanished);
         hiddenPlayersManager.enable();

--- a/velocity/src/main/java/codecrafter47/bungeetablistplus/BungeeTabListPlus.java
+++ b/velocity/src/main/java/codecrafter47/bungeetablistplus/BungeeTabListPlus.java
@@ -263,7 +263,6 @@ public class BungeeTabListPlus {
         hiddenPlayersManager.addVanishProvider("SuperVanish", BukkitData.SuperVanish_IsVanished);
         hiddenPlayersManager.addVanishProvider("CMI", BukkitData.CMI_IsVanished);
         hiddenPlayersManager.addVanishProvider("Essentials", BukkitData.Essentials_IsVanished);
-        hiddenPlayersManager.addVanishProvider("ProtocolVanish", BukkitData.ProtocolVanish_IsVanished);
         hiddenPlayersManager.addVanishProvider("Bukkit Player Metadata `vanished`", BukkitData.BukkitPlayerMetadataVanished);
         hiddenPlayersManager.addVanishProvider("Sponge VANISH", SpongeData.Sponge_IsVanished);
         hiddenPlayersManager.enable();

--- a/velocity/src/main/java/codecrafter47/bungeetablistplus/util/ReflectionUtil.java
+++ b/velocity/src/main/java/codecrafter47/bungeetablistplus/util/ReflectionUtil.java
@@ -77,7 +77,8 @@ public class ReflectionUtil {
                         (StateRegistry.PacketMapping) packetMapping.newInstance(0x5E, MINECRAFT_1_20_3, null, false),
                         (StateRegistry.PacketMapping) packetMapping.newInstance(0x60, MINECRAFT_1_20_5, null, false),
                         (StateRegistry.PacketMapping) packetMapping.newInstance(0x67, MINECRAFT_1_21_2, null, false),
-                        (StateRegistry.PacketMapping) packetMapping.newInstance(0x66, MINECRAFT_1_21_5, null, false)
+                        (StateRegistry.PacketMapping) packetMapping.newInstance(0x66, MINECRAFT_1_21_5, null, false),
+                        (StateRegistry.PacketMapping) packetMapping.newInstance(0x6B, MINECRAFT_1_21_9, null, false)
                 });
                 return;
             } catch (Exception e) {


### PR DESCRIPTION
This PR:
- Adds Velocity 1.21.9 and 1.21.10 support.
- Removes ProtocolVanish support, as it causes issues during building of the `minecraft-data-api` submodule, and has thus been removed from there.

Before merging, https://github.com/CodeCrafter47/minecraft-data-api/pull/11 needs to be pulled so we can update the submodule reference.

I'm testing the setup in my own server and it seems completely fine.